### PR TITLE
fix: footer style

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -70,7 +70,7 @@ const footer = (
   <Footer>
     Copyright &copy; 2024 -
     {' '}
-    <CurrentYear defaultYear={2025} />
+    <CurrentYear style={{ display: 'contents' }} defaultYear={2025} />
     {' '}
     CloudPilot AI, Inc. | Made with Nextra
   </Footer>


### PR DESCRIPTION
For some reason, the spaces around the `<span />` element are not rendered. Specify `display: content` on the `<span />` fixes this.